### PR TITLE
Remove artificial total count limit

### DIFF
--- a/src/SphinxEngine.php
+++ b/src/SphinxEngine.php
@@ -161,8 +161,7 @@ class SphinxEngine extends AbstractEngine
                 $totalCount = $value["Value"];
             }
         }
-        if ($totalCount >= 1000)
-            $totalCount = 999;
+        
         return $totalCount;
     }
 


### PR DESCRIPTION
We have a large dataset in Sphinx and we'd like to see the actual amount of results for our queries when using wildcard queries or otherwise. I don't see a reason this limit would need to remain for total_found (especially when paginating, a per-page limit of 1000 is quite high). Maybe I'm missing something?