### PR TITLE
Add support for Laravel Scout 9 (WIP)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,21 +3,15 @@
     "description": "Laravel Scout Sphinx Driver",
     "license": "MIT",
     "minimum-stability": "dev",
-    "repositories":[
-        {
-            "type": "git",
-            "url": "https://github.com/ben221199/SphinxQL-Query-Builder.git"
-        }
-    ],
     "require": {
-        "php": ">=7.0",
-        "laravel/scout": "^5.0|^6.0|^7.0|^8.0",
-        "foolz/sphinxql-query-builder": "dev-master"
+      "php": ">=7.0",
+      "laravel/scout": "^5.0|^6.0|^7.0|^8.0|^9.0",
+      "foolz/sphinxql-query-builder": "^3.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.5|^8|^9"
+      "roave/security-advisories": "dev-latest",
+      "mockery/mockery": "^1.0",
+      "phpunit/phpunit": "^7.5|^8|^9"
     },
     "extra": {
         "laravel": {

--- a/src/SphinxEngine.php
+++ b/src/SphinxEngine.php
@@ -130,7 +130,7 @@ class SphinxEngine extends AbstractEngine
         return $model->getScoutModelsByIds(
             $builder, $objectIds
         )->filter(static function (/** @var Searchable $model */ $model) use ($objectIds) {
-            return in_array($model->getScoutKey(), $objectIds, true);
+            return in_array($model->getScoutKey(), $objectIds, false);
         })->sortBy(static function (/** @var Searchable $model */ $model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();
@@ -157,7 +157,7 @@ class SphinxEngine extends AbstractEngine
         return $model->queryScoutModelsByIds(
             $builder, $objectIds
         )->cursor()->filter(function (/** @var Searchable $model */ $model) use ($objectIds) {
-            return in_array($model->getScoutKey(), $objectIds, true);
+            return in_array($model->getScoutKey(), $objectIds, false);
         })->sortBy(function (/** @var Searchable $model */ $model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();

--- a/src/SphinxEngine.php
+++ b/src/SphinxEngine.php
@@ -1,236 +1,285 @@
 <?php
 namespace Constantable\SphinxScout;
 
+use Exception;
 use Foolz\SphinxQL\Helper;
 use Foolz\SphinxQL\SphinxQL;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine as AbstractEngine;
 use Laravel\Scout\Searchable;
 
-class SphinxEngine extends AbstractEngine{
+class SphinxEngine extends AbstractEngine
+{
 
-	/**
-	 * @var SphinxQL
-	 */
-	protected $sphinx;
+    /**
+     * @var SphinxQL
+     */
+    protected $sphinx;
 
-	/**
-	 * @var array
-	 */
-	protected $whereIns = [];
+    /**
+     * @var array
+     */
+    protected $whereIns = [];
 
-	public function __construct($sphinx)
-	{
-		$this->sphinx = $sphinx;
-	}
+    public function __construct($sphinx)
+    {
+        $this->sphinx = $sphinx;
+    }
 
-	/**
-	 * Update the given model in the index.
-	 *
-	 * @param \Illuminate\Database\Eloquent\Collection $models
-	 * @return void
-	 */
-	public function update($models)
-	{
-		if ($models->isEmpty()) {
-			return;
-		}
-		$models->each(function ($model) {
-			if (!empty($searchableData = $model->toSearchableArray())) {
-				if (isset($model->isRT)) { // Only RT indexes support replace
-					$index = $model->searchableAs();
-					$searchableData['id'] = (int)$model->getKey();
-					$columns = array_keys($searchableData);
+    /**
+     * Update the given model in the index.
+     *
+     * @param \Illuminate\Database\Eloquent\Collection $models
+     * @return void
+     */
+    public function update($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+        $models->each(function ($model) {
+            if (!empty($searchableData = $model->toSearchableArray())) {
+                if (isset($model->isRT)) { // Only RT indexes support replace
+                    $index = $model->searchableAs();
+                    $searchableData['id'] = (int)$model->getKey();
+                    $columns = array_keys($searchableData);
 
-					$sphinxQuery = $this->sphinx
-						->replace()
-						->into($index)
-						->columns($columns)
-						->values($searchableData);
-					$sphinxQuery->execute();
-				}
-			}
-		});
-	}
+                    $sphinxQuery = $this->sphinx
+                        ->replace()
+                        ->into($index)
+                        ->columns($columns)
+                        ->values($searchableData);
+                    $sphinxQuery->execute();
+                }
+            }
+        });
+    }
 
-	/**
-	 * Remove the given model from the index.
-	 *
-	 * @param \Illuminate\Database\Eloquent\Collection $models *
-	 * @return void
-	 */
-	public function delete($models)
-	{
-		if ($models->isEmpty()) {
-			return;
-		}
-		$models->each(function ($model) {
-			if (isset($model->isRT)) { // Only RT indexes support deletes
-				$index = $model->searchableAs();
-				$key = $model->getKey();
-				$sphinxQuery = $this->sphinx
-					->delete()
-					->from($index)
-					->where('id', '=', $key);
-				$sphinxQuery->execute();
-			}
-		});
-	}
+    /**
+     * Remove the given model from the index.
+     *
+     * @param \Illuminate\Database\Eloquent\Collection $models *
+     * @return void
+     */
+    public function delete($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+        $models->each(function ($model) {
+            if (isset($model->isRT)) { // Only RT indexes support deletes
+                $index = $model->searchableAs();
+                $key = $model->getKey();
+                $sphinxQuery = $this->sphinx
+                    ->delete()
+                    ->from($index)
+                    ->where('id', '=', $key);
+                $sphinxQuery->execute();
+            }
+        });
+    }
 
-	/**
-	 * Perform the given search on the engine.
-	 *
-	 * @param Builder $builder
-	 * @return mixed
-	 * @throws
-	 */
-	public function search(Builder $builder)
-	{
-		return $this->performSearch($builder)->execute();
-	}
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param Builder $builder
+     * @return mixed
+     * @throws
+     */
+    public function search(Builder $builder)
+    {
+        return $this->performSearch($builder)->execute();
+    }
 
-	/**
-	 * Perform the given search on the engine.
-	 *
-	 * @param Builder $builder
-	 * @param int $perPage
-	 * @param int $page
-	 * @return mixed
-	 * @throws
-	 */
-	public function paginate(Builder $builder, $perPage, $page)
-	{
-		return $this->performSearch($builder)->limit($perPage * ($page - 1), $perPage)
-			->execute();
-	}
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param Builder $builder
+     * @param int $perPage
+     * @param int $page
+     * @return mixed
+     * @throws
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        return $this->performSearch($builder)->limit($perPage * ($page - 1), $perPage)
+            ->execute();
+    }
 
-	/**
-	 * Map the given results to instances of the given model.
-	 *
-	 * @param Builder $builder
-	 * @param mixed $results
-	 * @param Model|Searchable $model
-	 * @return \Illuminate\Database\Eloquent\Collection
-	 */
-	public function map(Builder $builder, $results, $model)
-	{
-		if ($results->count() === 0) {
-			return $model->newCollection();
-		}
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param Builder $builder
+     * @param mixed $results
+     * @param Model|Searchable $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        if ($results->count() === 0) {
+            return $model->newCollection();
+        }
 
-		$objectIds = collect($results->fetchAllAssoc())->pluck('id')->values()->all();
+        $objectIds = collect($results->fetchAllAssoc())->pluck('id')->values()->all();
 
-		$objectIdPositions = array_flip($objectIds);
+        $objectIdPositions = array_flip($objectIds);
 
-		return $model->getScoutModelsByIds(
-			$builder, $objectIds
-		)->filter(static function (/** @var Searchable $model */ $model) use ($objectIds) {
-			return in_array($model->getScoutKey(), $objectIds, true);
-		})->sortBy(static function (/** @var Searchable $model */ $model) use ($objectIdPositions) {
-			return $objectIdPositions[$model->getScoutKey()];
-		})->values();
-	}
+        return $model->getScoutModelsByIds(
+            $builder, $objectIds
+        )->filter(static function (/** @var Searchable $model */ $model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds, true);
+        })->sortBy(static function (/** @var Searchable $model */ $model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
 
-	/**
-	 * Pluck and return the primary keys of the given results.
-	 *
-	 * @param mixed $results
-	 * @return Collection
-	 */
-	public function mapIds($results)
-	{
-		return collect($results->fetchAllAssoc())->pluck('id')->values();
-	}
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param Builder $builder
+     * @param mixed $results
+     * @param Model|Searchable $model
+     * @return LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        if ($results->count() === 0) {
+            return LazyCollection::make($model->newCollection());
+        }
 
-	/**
-	 * Get the total count from a raw result returned by the engine.
-	 *
-	 * @param mixed $results
-	 * @return int
-	 * @throws
-	 */
-	public function getTotalCount($results)
-	{
-		$res = (new Helper($this->sphinx->getConnection()))->showMeta()->execute();
-		$assoc = $res->fetchAllAssoc();
-		$totalCount = $results->count();
-		foreach ($assoc as $item => $value) {
-			if ($value['Variable_name'] === 'total_found') {
-				$totalCount = $value['Value'];
-			}
-		}
+        $objectIds = collect($results->fetchAllAssoc())->pluck('id')->values()->all();
 
-		return $totalCount;
-	}
+        $objectIdPositions = array_flip($objectIds);
 
-	/**
-	 * Flush all of the model's records from the engine.
-	 *
-	 * @param Model $model
-	 * @return void
-	 * @throws
-	 */
-	public function flush($model)
-	{
-		if (isset($model->isRT)) { // Only RT indexes support truncate
-			$index = $model->searchableAs();
-			$res = (new Helper($this->sphinx->getConnection()))->truncateRtIndex($index)->execute();
-		}
-	}
+        return $model->queryScoutModelsByIds(
+            $builder, $objectIds
+        )->cursor()->filter(function (/** @var Searchable $model */ $model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds, true);
+        })->sortBy(function (/** @var Searchable $model */ $model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
 
-	/**
-	 * Perform the given search on the engine.
-	 *
-	 * @param Builder $builder
-	 * @return SphinxQL
-	 */
-	protected function performSearch(Builder $builder){
-		/**
-		 * @var Searchable $model
-		 */
-		$model = $builder->model;
-		$index = $model->searchableAs();
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param mixed $results
+     * @return Collection
+     */
+    public function mapIds($results)
+    {
+        return collect($results->fetchAllAssoc())->pluck('id')->values();
+    }
 
-		$query = $this->sphinx
-			->select('*', SphinxQL::expr('WEIGHT() AS weight'))
-			->from($index)
-			->match('*', SphinxQL::expr('"' . $builder->query . '"/1'))
-			->limit($builder->limit??20);
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param mixed $results
+     * @return int
+     * @throws
+     */
+    public function getTotalCount($results)
+    {
+        $res = (new Helper($this->sphinx->getConnection()))->showMeta()->execute();
+        $assoc = $res->fetchAllAssoc();
+        $totalCount = $results->count();
+        foreach ($assoc as $item => $value) {
+            if ($value['Variable_name'] === 'total_found') {
+                $totalCount = $value['Value'];
+            }
+        }
 
-		foreach ($builder->wheres as $clause => $filters) {
-			$query->where($clause, '=', $filters);
-		}
+        return $totalCount;
+    }
 
-		foreach ($this->whereIns as $whereIn) {
-			$query->where(key($whereIn), 'IN', $whereIn[key($whereIn)]);
-		}
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param Model $model
+     * @return void
+     * @throws
+     */
+    public function flush($model)
+    {
+        if (isset($model->isRT)) { // Only RT indexes support truncate
+            $index = $model->searchableAs();
+            $res = (new Helper($this->sphinx->getConnection()))->truncateRtIndex($index)->execute();
+        }
+    }
 
-		if ($builder->callback) {
-			call_user_func(
-				$builder->callback,
-				$query
-			);
-		}
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param Builder $builder
+     * @return SphinxQL
+     */
+    protected function performSearch(Builder $builder)
+    {
+        /**
+         * @var Searchable $model
+         */
+        $model = $builder->model;
+        $index = $model->searchableAs();
 
-		if (empty($builder->orders)) {
-			$query->orderBy('weight', 'DESC');
-		} else {
-			foreach ($builder->orders as $order) {
-				$query->orderBy($order['column'], $order['direction']);
-			}
-		}
+        $query = $this->sphinx
+            ->select('*', SphinxQL::expr('WEIGHT() AS weight'))
+            ->from($index)
+            ->match('*', SphinxQL::expr('"' . $builder->query . '"/1'))
+            ->limit($builder->limit ?? 20);
 
-		return $query;
-	}
+        foreach ($builder->wheres as $clause => $filters) {
+            $query->where($clause, '=', $filters);
+        }
 
-	/**
-	 * @param string $attribute
-	 * @param array $arrayIn
-	 */
-	public function addWhereIn(string $attribute, array $arrayIn){
-		$this->whereIns[] = array($attribute => $arrayIn);
-	}
+        foreach ($this->whereIns as $whereIn) {
+            $query->where(key($whereIn), 'IN', $whereIn[key($whereIn)]);
+        }
 
+        if ($builder->callback) {
+            call_user_func(
+                $builder->callback,
+                $query
+            );
+        }
+
+        if (empty($builder->orders)) {
+            $query->orderBy('weight', 'DESC');
+        } else {
+            foreach ($builder->orders as $order) {
+                $query->orderBy($order['column'], $order['direction']);
+            }
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param string $attribute
+     * @param array $arrayIn
+     */
+    public function addWhereIn(string $attribute, array $arrayIn)
+    {
+        $this->whereIns[] = array($attribute => $arrayIn);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
+    public function createIndex($name, array $options = [])
+    {
+        throw new Exception('Sphinx indexes must be defined in sphinx.conf.');
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
+    public function deleteIndex($name)
+    {
+        throw new Exception('Sphinx indexes must be removed from sphinx.conf.');
+    }
 }


### PR DESCRIPTION
This PR adds support for Laravel Scout 9. It also removes the reference to SphinxQL-Query-Builder in a forked repository and uses the latest version, ^3.0, instead. This is the same PR as https://github.com/constantable/laravel-scout-sphinx/pull/15 with the difference being support for Scout 9.

This PR also fixes a bug in which no results are returned because of a strict comparison between Laravel's models' IDs as integers and IDs returned from Sphinx as strings.