### PR TITLE
removed hard-coded query option

### DIFF
--- a/src/SphinxEngine.php
+++ b/src/SphinxEngine.php
@@ -227,7 +227,7 @@ class SphinxEngine extends AbstractEngine
         $query = $this->sphinx
             ->select('*', SphinxQL::expr('WEIGHT() AS weight'))
             ->from($index)
-            ->match('*', SphinxQL::expr('"' . $builder->query . '"/1'))
+            ->match('*', SphinxQL::expr($builder->query))
             ->limit($builder->limit ?? 20);
 
         foreach ($builder->wheres as $clause => $filters) {


### PR DESCRIPTION
it is better to give the ability to specify search options in the request, like:
```
return self::search('"' . $term . '"/1')
            ->get();
```
or
```
return self::search('"' . $term . '"/3')
            ->get();
```
or
```
return self::search('"' . $term . '"~10')
            ->get();
```
more options is here http://sphinxsearch.com/docs/current/extended-syntax.html